### PR TITLE
Fix handling of ! required cards when a dominion or fortress is in the deck

### DIFF
--- a/deck.cpp
+++ b/deck.cpp
@@ -232,6 +232,7 @@ void Deck::set(const std::vector<unsigned>& ids, const std::map<signed, char> &m
             }
             else
             {
+                non_deck_cards_seen++;
                 std::cerr << "WARNING: Ignoring additional commander " << card->m_name << " (" << commander->m_name << " already in deck)\n";
             }
         }

--- a/deck.cpp
+++ b/deck.cpp
@@ -217,6 +217,8 @@ void Deck::set(const std::vector<unsigned>& ids, const std::map<signed, char> &m
 {
     commander = nullptr;
     strategy = DeckStrategy::random;
+
+    int non_deck_cards_seen = 0;
     for(auto id: ids)
     {
         const Card* card{all_cards.by_id(id)};
@@ -225,6 +227,8 @@ void Deck::set(const std::vector<unsigned>& ids, const std::map<signed, char> &m
             if (commander == nullptr)
             {
                 commander = card;
+                if (marks.find(-1) != marks.end())
+                    card_marks[-1] = marks.at(-1);
             }
             else
             {
@@ -234,14 +238,21 @@ void Deck::set(const std::vector<unsigned>& ids, const std::map<signed, char> &m
         else if (card->m_category == CardCategory::dominion)
         {
             dominion_cards.emplace_back(card);
+            non_deck_cards_seen++;
         }
         else if (card->m_category == CardCategory::fortress_defense || card->m_category == CardCategory::fortress_siege)
         {
             fortress_cards.emplace_back(card);
+            non_deck_cards_seen++;
         }
         else
         {
             cards.emplace_back(card);
+            int mark_dst = cards.size() - 1;
+            int mark_src = mark_dst + non_deck_cards_seen;
+
+            if (marks.find(mark_src) != marks.end())
+                card_marks[mark_dst] = marks.at(mark_src);
         }
     }
     if (commander == nullptr)
@@ -250,7 +261,6 @@ void Deck::set(const std::vector<unsigned>& ids, const std::map<signed, char> &m
     }
     commander_max_level = commander->m_top_level_card->m_level;
     deck_size = cards.size();
-    card_marks = marks;
 }
 
 void Deck::set(const std::string& deck_string_)


### PR DESCRIPTION
Fix handling of card marks (such as the ! for required) when dominions or fortresses are present in the deck. Without this fix, a commande like this won't ever swap out the commander:

./tuo "Halcyon, Alpha Dominion, !Sleek Beamshot #10" SomeGauntlet -r -s -o=data/all-commanders.txt climb 100

It should be able to replace the commander, but the card marks for the
beamshots end up off by one. With this fix it works
correctly. (Required marks for Dominions end up dropped, but that's
ok, because at least currently tuo will never replace the dominion
anyway.)